### PR TITLE
include SemanticLogger::Loggable in ActiveModelSerializers::Serializa…

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_model_serializers/logging.rb
+++ b/lib/rails_semantic_logger/extensions/active_model_serializers/logging.rb
@@ -9,3 +9,7 @@ module ActiveModelSerializers::Logging
     logger.tagged(*tags, &block)
   end
 end
+
+class ActiveModelSerializers::SerializableResource
+  include SemanticLogger::Loggable
+end


### PR DESCRIPTION
Semantic Logger still generates an undefined method logger error on ActiveModelSerializer 0.10.2.  This patch mixes Loggable into the offending class.