### PR TITLE
Fix for #35

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/action_controller/log_subscriber.rb
@@ -11,7 +11,7 @@ module ActionController
     def process_action(event)
       controller_logger(event).info do
         payload = event.payload.dup
-        payload[:params].except!(*INTERNAL_PARAMS)
+        payload[:params] = payload[:params].to_unsafe_h.except(*INTERNAL_PARAMS)
         payload.delete(:params) if payload[:params].empty?
 
         format           = payload[:format]


### PR DESCRIPTION
@reidmorrison's solution for the issue #35

> Since Semantic Logger wants a hash, and we would probably want all parameters, since that is what it appears Rails is logging in #inspect, how about the following change?