### PR TITLE
Fix log_subscriber monkey patch for Rails 5.0.3.

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
@@ -20,13 +20,12 @@ module ActiveRecord
       }
       unless (payload[:binds] || []).empty?
         log_payload[:binds] = binds = {}
-        # Changed with Rails 5
-        if Rails.version.to_f >= 5.1
+        if Rails.version >= "5.0.3"
           casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
           payload[:binds].zip(casted_params).map { |attr, value|
             render_bind(attr, value)
           }
-        elsif Rails.version.to_i >= 5
+        elsif Rails.version >= "5.0.0"
           payload[:binds].each do |attr|
             attr_name, value = render_bind(attr)
             binds[attr_name] = value


### PR DESCRIPTION
We just updated to Rails 5.0.3 and noticed we were getting exceptions when running `rails db:reset`. It turns out that the [API changed in 5.0.3](https://github.com/rails/rails/compare/v5.0.2...v5.0.3#diff-eba6b59bacb9a1d88646145ed1ff4c86R54) to match 5.1.

This patch changes the version sniffing to assume >= 5.0.3 will use the new API. It's possible that it may change back to 5.0.2 behaviour in a 5.0.4 release, but we should be able to handle this with additional predicates.

Before

![untitled-1](https://cloud.githubusercontent.com/assets/19860/26043624/f703f052-3981-11e7-9db2-1101ecfa02b0.png)

After

![untitled-2](https://cloud.githubusercontent.com/assets/19860/26043627/fb0ce82a-3981-11e7-9e72-54814fb5cd95.png)

Couple of questions:

1. Are you okay with changing the version sniffing to do string comparisons? It lets you easily test against the patch number.
2. I wasn't sure how far to go with testing. Do you want to test against 5.0.3 as well as 5.x? It looks like we assume the latest stable version is good enough.

Feedback welcome.