### PR TITLE
If logger doesn't exist, fallback to ActionController::Base.logger

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/action_controller/log_subscriber.rb
@@ -89,7 +89,7 @@ module ActionController
     def controller_logger(event)
       if controller = event.payload[:controller]
         begin
-          controller.constantize.logger
+          controller.constantize.logger || ActionController::Base.logger
         rescue NameError
           ActionController::Base.logger
         end

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,0 +1,49 @@
+require_relative "../test_helper"
+
+class DashboardControllerTest < ActionController::TestCase
+  describe DashboardController do
+    before do
+      # Use a mock logger that just keeps the last logged entry in an instance variable
+      SemanticLogger.default_level   = :trace
+      SemanticLogger.backtrace_level = nil
+      @mock_logger                   = MockLogger.new
+      @appender                      = SemanticLogger.add_appender(logger: @mock_logger, formatter: :raw)
+      @logger                        = SemanticLogger['Test']
+
+      assert_equal [], SemanticLogger.tags
+      assert_equal 65535, SemanticLogger.backtrace_level_index
+    end
+
+    after do
+      SemanticLogger.remove_appender(@appender)
+    end
+
+    describe 'GET #show' do
+      before do
+        get :show
+      end
+
+      it 'has no errors' do
+        assert_response :success
+      end
+
+      it 'successfully logs message' do
+        SemanticLogger.flush
+        actual = @mock_logger.message
+
+        assert_equal 'Completed #show', actual[:message]
+
+        assert payload = actual[:payload], actual
+        assert_equal 'show', payload[:action], payload
+        assert_equal 'DashboardController', payload[:controller], payload
+        assert_equal 'HTML', payload[:format], payload
+        assert_equal 'GET', payload[:method], payload
+
+        assert_equal '/dashboard', payload[:path], payload
+        assert_equal 200, payload[:status], payload
+        assert_equal 'OK', payload[:status_message], payload
+      end
+
+    end
+  end
+end

--- a/test/dummy/app/controllers/application_metal_controller.rb
+++ b/test/dummy/app/controllers/application_metal_controller.rb
@@ -1,0 +1,13 @@
+class ApplicationMetalController < ActionController::Metal
+  MODULES = [
+    ActionController::Instrumentation,
+    AbstractController::Rendering,
+    ActionController::Rendering,
+    ActionController::Renderers::All,
+    # Helpers::Controller
+  ].freeze
+
+  MODULES.each do |mod|
+    include mod
+  end
+end

--- a/test/dummy/app/controllers/dashboard_controller.rb
+++ b/test/dummy/app/controllers/dashboard_controller.rb
@@ -1,0 +1,8 @@
+class DashboardController < ApplicationMetalController
+
+
+  def show
+
+  end
+
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,5 +3,7 @@ Dummy::Application.routes.draw do
 
   resources :articles
 
+  resource :dashboard, controller: :dashboard
+
   root 'welcome#index'
 end


### PR DESCRIPTION
Ultimately, `rails_semantic_logger` should be configurable to use a different class as the base.

Most (rails) applications apply modifications at the `ApplicationController` level, such as including `SemanticLogger::Loggable`. Gems/Libraries such as `Doorkeeper` (ironically an example where this is breaking and the catalyst for this fix) allow the developer to configure the class name of which all controllers inherit from.

```
Doorkeeper.configure do
  base_controller 'ApplicationController'
end
```

`Doorkeeper` coincidentally has a few controllers that do not inherit from `ActionController::Base`, so, even if `rails_semantic_logger` provided a configuration option for `base_controller` (similar to `Doorkeeper`), this illustrates a situation where `rails_semantic_logger` could be a bit more lenient/defensible when it comes to finding an appropriate logger to use.