### PR TITLE
Fix type_casted_binds call with one parameter for Rails 5.1.5

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
@@ -29,12 +29,12 @@ module ActiveRecord
             attr_name, value = render_bind(attr)
             binds[attr_name] = value
           end
-        elsif Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR <= 1 # 5.0.3 - 5.1.x
+        elsif Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR <= 1 && (Rails::VERSION::MINOR == 0 || Rails::VERSION::TINY <= 4) # 5.0.3 - 5.1.4
           casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
           payload[:binds].zip(casted_params).map { |attr, value|
             render_bind(attr, value)
           }
-        elsif Rails::VERSION::MAJOR >= 5 # >= 5.2
+        elsif Rails::VERSION::MAJOR >= 5 # >= 5.1.5
           casted_params = type_casted_binds(payload[:type_casted_binds])
           payload[:binds].zip(casted_params).map do |attr, value|
             render_bind(attr, value)


### PR DESCRIPTION
As mentioned in https://github.com/rocketjob/rails_semantic_logger/issues/55 Rails 5.1.5 changed the method `type_casted_binds` to accept only one parameter:
https://github.com/rails/rails/blob/v5.1.5/activerecord/lib/active_record/log_subscriber.rb#L45

Using the same approach as for Rails 5.2 solves the issue.