### PR TITLE
 Fix problem for the attributes with several values for some Rails version

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
@@ -33,7 +33,7 @@ module ActiveRecord
           casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
           payload[:binds].zip(casted_params).map { |attr, value|
             attr_name, value = render_bind(attr, value)
-            binds[attr_name] = value
+            (binds[attr_name] ||= []) << value
           }
         elsif Rails::VERSION::MAJOR >= 5 # >= 5.1.5
           casted_params = type_casted_binds(payload[:type_casted_binds])


### PR DESCRIPTION
In binds placed the arrays of values instead values
This fix missed values. For example when we use BETWEEN as attribute i want see both edges of range.
Probably the same fix you'll used in other versions of Rails