### PR TITLE
Use 5.1.5 method of binding values when using Rails 5.0.7

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
@@ -26,9 +26,9 @@ module ActiveRecord
         log_payload[:binds] =
           if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 0 && Rails::VERSION::TINY <= 2 # 5.0.0 - 5.0.2
             bind_values_v5_0_0(payload)
-          elsif Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR <= 1 && (Rails::VERSION::MINOR == 0 || Rails::VERSION::TINY <= 4) # 5.0.3 - 5.1.4
+          elsif Rails::VERSION::MAJOR >= 5 && ((Rails::VERSION::MINOR == 0 && Rails::VERSION::TINY <= 6) || (Rails::VERSION::MINOR == 1 && Rails::VERSION::TINY <= 4)) # 5.0.3 - 5.0.6 && 5.1.0 - 5.1.4
             bind_values_v5_0_3(payload)
-          elsif Rails::VERSION::MAJOR >= 5 # >= 5.1.5
+          elsif Rails::VERSION::MAJOR >= 5 # >= 5.1.5 && 5.0.7
             bind_values_v5_1_5(payload)
           elsif Rails.version.to_i >= 4 # 4.x
             bind_values_v4(payload)


### PR DESCRIPTION
Looks like 5.0.7 also has the single-parameter version of
type_casted_binds:

https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/log_subscriber.rb#L50


Related to #60 