### PR TITLE
DelayedJob Logging Fix

### DIFF
--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -15,6 +15,9 @@ module RailsSemanticLogger
   module Rack
     autoload :Logger, 'rails_semantic_logger/rack/logger'
   end
+  module DelayedJob
+    autoload :Plugin, 'rails_semantic_logger/delayed_job/plugin.rb'
+  end
 
   # Swap an existing subscriber with a new one
   def self.swap_subscriber(old_class, new_class, notifier)

--- a/lib/rails_semantic_logger/delayed_job/plugin.rb
+++ b/lib/rails_semantic_logger/delayed_job/plugin.rb
@@ -1,0 +1,11 @@
+module RailsSemanticLogger
+  module DelayedJob
+    class Plugin < Delayed::Plugin
+      callbacks do |lifecycle|
+        lifecycle.before(:execute) do |job, &block|
+          ::SemanticLogger.reopen
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -261,3 +261,14 @@ module RailsSemanticLogger
     end
   end
 end
+
+if defined?(Delayed::Worker)
+  class SemanticLoggerPlugin < Delayed::Plugin
+    callbacks do |lifecycle|
+      lifecycle.before(:execute) do |job, &block|
+        ::SemanticLogger.reopen
+       end
+     end
+   end
+  Delayed::Worker.plugins << SemanticLoggerPlugin
+end


### PR DESCRIPTION
Currently, the DelayedJob logging integration does not work when the workers are started using the `bin/delayed_job start` command included in the gem to create multiple workers as daemons. This is because the file handle is not being re-opened after the daemon processes are forked.

This PR adds a custom Delayed::Plugin to reopen the log file before the worker begins picking up jobs.