### PR TITLE
don't require ActiveRecord if it's not already available

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -1,4 +1,3 @@
-require 'active_record/log_subscriber'
 require 'action_controller/log_subscriber'
 
 module RailsSemanticLogger
@@ -222,11 +221,15 @@ module RailsSemanticLogger
 
       if config.rails_semantic_logger.semantic
         # Active Record
-        RailsSemanticLogger.swap_subscriber(
-          ::ActiveRecord::LogSubscriber,
-          RailsSemanticLogger::ActiveRecord::LogSubscriber,
-          :active_record
-        )
+        if defined?(::ActiveRecord)
+          require 'active_record/log_subscriber'
+
+          RailsSemanticLogger.swap_subscriber(
+            ::ActiveRecord::LogSubscriber,
+            RailsSemanticLogger::ActiveRecord::LogSubscriber,
+            :active_record
+          )
+        end
 
         # Rack
         RailsSemanticLogger::Rack::Logger.started_request_log_level = :info if config.rails_semantic_logger.started


### PR DESCRIPTION
### Issue # (if available)

If ActiveRecord is available, but not previously required this breaks auto-detection for [some other gems](https://github.com/CanCanCommunity/cancancan/blob/1.17.0/lib/cancan/controller_resource.rb#L224)

For example

```ruby
if defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 3
```
This will fail with `uninitialized constant ActiveRecord::VERSION` if full active record is not required, as the gem only requires the log subscriber.


### Description of changes

Conditionally require `active_record/log_subscriber` only if `ActiveRecord` is already defined


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
