### PR TITLE
Include query source in activerecord logs

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -31,7 +31,7 @@ module RailsSemanticLogger
 
         log_payload         = {sql: payload[:sql]}
         log_payload[:binds] = bind_values(payload) unless (payload[:binds] || []).empty?
-        log_payload[:query_source] = query_source if ::ActiveRecord::Base.verbose_query_logs
+        log_payload[:query_source] = query_source if log_query_source?
 
         log = {
           message:  name,
@@ -60,6 +60,10 @@ module RailsSemanticLogger
 
       def logger
         self.class.logger
+      end
+
+      def log_query_source?
+        Rails.version.to_f >= 5.2 && ::ActiveRecord::Base.verbose_query_logs
       end
 
       def query_source

--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -31,6 +31,7 @@ module RailsSemanticLogger
 
         log_payload         = {sql: payload[:sql]}
         log_payload[:binds] = bind_values(payload) unless (payload[:binds] || []).empty?
+        log_payload[:query_source] = query_source if ::ActiveRecord::Base.verbose_query_logs
 
         log = {
           message:  name,
@@ -59,6 +60,14 @@ module RailsSemanticLogger
 
       def logger
         self.class.logger
+      end
+
+      def query_source
+        backtrace_cleaner.clean(caller).first
+      end
+
+      def backtrace_cleaner
+        @backtrace_cleaner ||= Rails::BacktraceCleaner.new
       end
 
       #

--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -67,11 +67,7 @@ module RailsSemanticLogger
       end
 
       def query_source
-        backtrace_cleaner.clean(caller).first
-      end
-
-      def backtrace_cleaner
-        @backtrace_cleaner ||= Rails::BacktraceCleaner.new
+        Rails.backtrace_cleaner.clean(caller).first
       end
 
       #

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -10,6 +10,7 @@ class ActiveRecordTest < Minitest::Test
       @appender                      = SemanticLogger.add_appender(logger: @mock_logger, formatter: :raw)
       @logger                        = SemanticLogger['Test']
       @hash                          = {session_id: 'HSSKLEU@JDK767', tracking_number: 12_345}
+      ::ActiveRecord::Base.verbose_query_logs = true
 
       assert_equal [], SemanticLogger.tags
       assert_equal 65_535, SemanticLogger.backtrace_level_index
@@ -28,6 +29,7 @@ class ActiveRecordTest < Minitest::Test
         assert actual[:message].include?('Sample'), actual[:message]
         assert actual[:payload], actual
         assert actual[:payload][:sql], actual[:payload]
+        assert_match /active_record_test.rb:25/, actual[:payload][:query_source]
       end
 
       it 'single bind value' do

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -10,7 +10,10 @@ class ActiveRecordTest < Minitest::Test
       @appender                      = SemanticLogger.add_appender(logger: @mock_logger, formatter: :raw)
       @logger                        = SemanticLogger['Test']
       @hash                          = {session_id: 'HSSKLEU@JDK767', tracking_number: 12_345}
-      ::ActiveRecord::Base.verbose_query_logs = true
+
+      if Rails.version.to_f >= 5.2
+        ::ActiveRecord::Base.verbose_query_logs = true
+      end
 
       assert_equal [], SemanticLogger.tags
       assert_equal 65_535, SemanticLogger.backtrace_level_index
@@ -29,7 +32,10 @@ class ActiveRecordTest < Minitest::Test
         assert actual[:message].include?('Sample'), actual[:message]
         assert actual[:payload], actual
         assert actual[:payload][:sql], actual[:payload]
-        assert_match /active_record_test.rb:25/, actual[:payload][:query_source]
+
+        if Rails.version.to_f >= 5.2
+          assert_match /active_record_test.rb:25/, actual[:payload][:query_source]
+        end
       end
 
       it 'single bind value' do


### PR DESCRIPTION
This is done by default since rails 5.2 in the main rails logsubscriber. Implementation is stolen from
current implementation of rails default logsubscriber:

https://github.com/rails/rails/blob/c675783eb4fb42a357ec068d4cfd83bf08f78aea/activerecord/lib/active_record/log_subscriber.rb

### Issue # (if available)


### Description of changes

ActiveRecord query log payload now contains `query_source` - reference to the line where query was made from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
