### PR TITLE
Fix scope for ActiveRecord::Base

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -155,7 +155,7 @@ module RailsSemanticLogger
       end
 
       def type_casted_binds_v5_0_3(binds, casted_binds)
-        casted_binds || ActiveRecord::Base.connection.type_casted_binds(binds)
+        casted_binds || ::ActiveRecord::Base.connection.type_casted_binds(binds)
       end
 
       def type_casted_binds_v5_1_5(casted_binds)


### PR DESCRIPTION
Fix for:
``` NameError: uninitialized constant RailsSemanticLogger::ActiveRecord::Base```