### PR TITLE
Test against Ruby 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ rvm:
 - 2.3.8
 - 2.4.5
 - 2.5.3
-- 2.6.0-preview2
+- 2.6.1
+- ruby-head
 - jruby-9.2.3.0
 
 matrix:


### PR DESCRIPTION
### Issue # (if available)
This pull request updates the Travis configuration to test against Ruby 2.6.1. Now that Ruby 2.6.1 is in a stable release, we should test against it. I also added `ruby-head` to the matrix as an allowed failure. This should help identify issues ahead of time. If you would like me to remove it, just let me know.

