### PR TITLE
Freeze semantic_logger minor version

### DIFF
--- a/rails_semantic_logger.gemspec
+++ b/rails_semantic_logger.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.license               = 'Apache-2.0'
   spec.required_ruby_version = '>= 2.3'
   spec.add_dependency 'rails', '>= 3.2'
-  spec.add_dependency 'semantic_logger', '~> 4.3'
+  spec.add_dependency 'semantic_logger', '~> 4.3.0'
 end


### PR DESCRIPTION
We need freeze minor version  after release v4.4.0 with https://github.com/rocketjob/semantic_logger/commit/859fb1c720dfebc1519f62492ed168ce90a8711e 
This version uses `SemanticLogger::Processor.instance` instead of `SemanticLogger::Logger.processor` like in semantic_logger@4.4.0