### PR TITLE
Add proper ActiveJob events subscription

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_job/logging.rb
+++ b/lib/rails_semantic_logger/extensions/active_job/logging.rb
@@ -10,5 +10,124 @@ module ActiveJob
     def tag_logger(*tags, &block)
       logger.tagged(*tags, &block)
     end
+
+    class LogSubscriber < ActiveSupport::LogSubscriber
+      def enqueue(event)
+        log_with_formatter event: event do |fmt|
+          "Enqueued #{fmt.job_info}"
+        end
+      end
+
+      def enqueue_at(event)
+        log_with_formatter event: event do |fmt|
+          "Enqueued #{fmt.job_info} at #{fmt.scheduled_at}"
+        end
+      end
+
+      def perform_start(event)
+        log_with_formatter event: event do |fmt|
+          "Performing #{fmt.job_info}"
+        end
+      end
+
+      def perform(event)
+        ex = event.payload[:exception_object]
+        if ex
+          logger.error ex
+        else
+          log_with_formatter event: event, log_duration: true do |fmt|
+            "Performed #{fmt.job_info} in #{event.duration.round(2)}ms"
+          end
+        end
+      end
+
+      private
+
+      class EventFormatter
+        def initialize(event:, log_duration: false)
+          @event = event
+          @log_duration = log_duration
+        end
+
+        def job_info
+          "#{job.class.name} (Job ID: #{job.job_id}) to #{queue_name}"
+        end
+
+        def payload
+          {}.tap do |h|
+            h[:event_name]      = event.name
+            h[:adapter]         = adapter_name
+            h[:queue]           = job.queue_name
+            h[:job_class]       = job.class.name
+            h[:job_id]          = job.job_id
+            h[:provider_job_id] = job.provider_job_id
+            h[:duration]        = event.duration.round(2) if log_duration?
+            h[:arguments]       = formatted_args
+          end
+        end
+
+        def queue_name
+          adapter_name + "(#{job.queue_name})"
+        end
+
+        def scheduled_at
+          Time.at(event.payload[:job].scheduled_at).utc
+        end
+
+        private
+
+        attr_reader :event
+
+        def job
+          event.payload[:job]
+        end
+
+        def adapter_name
+          event.payload[:adapter].class.name.demodulize.remove('Adapter')
+        end
+
+        def formatted_args
+          JSON.pretty_generate(job.arguments.map { |arg| format(arg) })
+        end
+
+        def format(arg)
+          case arg
+          when Hash
+            arg.transform_values { |value| format(value) }
+          when Array
+            arg.map { |value| format(value) }
+          when GlobalID::Identification
+            begin
+              arg.to_global_id
+            rescue StandardError
+              arg
+            end
+          else
+            arg
+          end
+        end
+
+        def log_duration?
+          @log_duration
+        end
+      end
+
+      def log_with_formatter(**kw_args)
+        fmt = EventFormatter.new(**kw_args)
+        msg = yield fmt
+        logger.info msg, fmt.payload
+      end
+
+      def logger
+        ActiveJob::Base.logger
+      end
+    end
   end
 end
+
+ActiveSupport::Notifications.unsubscribe('perform_start.active_job')
+ActiveSupport::Notifications.unsubscribe('perform.active_job')
+ActiveSupport::Notifications.unsubscribe('enqueue_at.active_job')
+ActiveSupport::Notifications.unsubscribe('enqueue.active_job')
+
+ActiveJob::Logging::LogSubscriber.attach_to :active_job

--- a/lib/rails_semantic_logger/extensions/active_job/logging.rb
+++ b/lib/rails_semantic_logger/extensions/active_job/logging.rb
@@ -60,7 +60,7 @@ module ActiveJob
             h[:queue]           = job.queue_name
             h[:job_class]       = job.class.name
             h[:job_id]          = job.job_id
-            h[:provider_job_id] = job.provider_job_id
+            h[:provider_job_id] = job.try(:provider_job_id) # Not available in Rails 4.2
             h[:duration]        = event.duration.round(2) if log_duration?
             h[:arguments]       = formatted_args
           end
@@ -125,9 +125,11 @@ module ActiveJob
   end
 end
 
-ActiveSupport::Notifications.unsubscribe('perform_start.active_job')
-ActiveSupport::Notifications.unsubscribe('perform.active_job')
-ActiveSupport::Notifications.unsubscribe('enqueue_at.active_job')
-ActiveSupport::Notifications.unsubscribe('enqueue.active_job')
+if defined?(ActiveSupport::Notifications)
+  ActiveSupport::Notifications.unsubscribe('perform_start.active_job')
+  ActiveSupport::Notifications.unsubscribe('perform.active_job')
+  ActiveSupport::Notifications.unsubscribe('enqueue_at.active_job')
+  ActiveSupport::Notifications.unsubscribe('enqueue.active_job')
 
-ActiveJob::Logging::LogSubscriber.attach_to :active_job
+  ActiveJob::Logging::LogSubscriber.attach_to :active_job
+end

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -35,6 +35,10 @@ class ActiveJobTest < Minitest::Test
     end
 
     describe 'Logging::LogSubscriber' do
+      before do
+        skip 'Older rails does not support ActiveSupport::Notification' unless defined?(ActiveSupport::Notifications)
+      end
+
       let(:subscriber) { ActiveJob::Logging::LogSubscriber.new }
 
       let(:event) do

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -9,6 +9,14 @@ class ActiveJobTest < Minitest::Test
         "Received: #{record}"
       end
     end
+
+    class TestModel
+      include GlobalID::Identification
+
+      def id
+        15
+      end
+    end
   end
 
   describe 'ActiveJob' do
@@ -23,6 +31,83 @@ class ActiveJobTest < Minitest::Test
 
       it 'runs the job' do
         MyJob.perform_now('hello')
+      end
+    end
+
+    describe 'Logging::LogSubscriber' do
+      let(:subscriber) { ActiveJob::Logging::LogSubscriber.new }
+
+      let(:event) do
+        ActiveSupport::Notifications::Event.new 'enqueue.active_job',
+                                                5.seconds.ago,
+                                                Time.zone.now,
+                                                SecureRandom.uuid,
+                                                adapter: ActiveJob::QueueAdapters::InlineAdapter.new,
+                                                job: job
+      end
+
+      let(:job) do
+        MyJob.new(TestModel.new, 1, 'string', foo: 'bar')
+      end
+
+      %i[enqueue enqueue_at perform_start perform].each do |method|
+        describe "##{method}" do
+          specify do
+            job.stub(:scheduled_at, Time.zone.now.to_i) do
+              assert_send([ActiveJob::Base.logger, :info])
+              subscriber.public_send(method, event)
+            end
+          end
+        end
+      end
+
+      describe 'ActiveJob::Logging::LogSubscriber::EventFormatter' do
+        let(:formatter) do
+          ActiveJob::Logging::LogSubscriber::EventFormatter.new(event: event, log_duration: true)
+        end
+
+        let(:event) do
+          ActiveSupport::Notifications::Event.new 'perform.active_job',
+                                                  5.seconds.ago,
+                                                  Time.zone.now,
+                                                  'transaction_id',
+                                                  adapter: ActiveJob::QueueAdapters::InlineAdapter.new,
+                                                  job: MyJob.new(TestModel.new, 1, 'string', foo: 'bar')
+        end
+
+        describe '#payload' do
+          specify do
+            assert_equal(formatter.payload[:event_name], 'perform.active_job')
+            assert_equal(formatter.payload[:adapter], 'Inline')
+            assert_equal(formatter.payload[:queue], 'my_jobs')
+            assert_equal(formatter.payload[:job_class], 'ActiveJobTest::MyJob')
+            assert_kind_of(String, formatter.payload[:job_id])
+            assert_kind_of(Float, formatter.payload[:duration])
+            arguments = <<~ARGS.chomp
+              [
+                "gid://dummy/ActiveJobTest::TestModel/15",
+                1,
+                "string",
+                {
+                  "foo": "bar"
+                }
+              ]
+            ARGS
+            assert_equal(formatter.payload[:arguments], arguments)
+          end
+        end
+
+        describe '#job_info' do
+          specify do
+            assert_match(/^ActiveJobTest::MyJob \(Job ID: [a-z\-0-9]+\) to Inline\(my_jobs\)$/, formatter.job_info)
+          end
+        end
+
+        describe '#queue_name' do
+          specify do
+            assert_equal(formatter.queue_name, 'Inline(my_jobs)')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Issue # (if available)

Right now when I add `rails_semantic_logger` to an application with `active_job` I have rather useless lines in the log. However this could/should be improved. Events have structured payload which comes handy in the logs.

https://github.com/rails/rails/blob/master/activejob/lib/active_job/logging.rb

One probably would want to refuse native job adapter logging when this one is setup.

### Description of changes

Overriding `ActiveJob::Logging::LogSubscriber` and re-subscribing to the `*.active_job` events does the trick.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
