### PR TITLE
Add the dependencies we actually use.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ gem 'sqlite3', '~> 1.3.0', platform: :ruby
 
 # gem 'rails', '~> 5.2.0'
 gem 'rails', '6.0.0.beta1'
+gem 'tzinfo-data'

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -1,3 +1,4 @@
+require 'rails'
 require 'action_controller/log_subscriber'
 require 'rails_semantic_logger/options'
 

--- a/rails_semantic_logger.gemspec
+++ b/rails_semantic_logger.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.files                 = Dir['lib/**/*', 'LICENSE.txt', 'Rakefile', 'README.md']
   spec.license               = 'Apache-2.0'
   spec.required_ruby_version = '>= 2.3'
-  spec.add_dependency 'rails', '>= 3.2'
+  spec.add_dependency 'railties', '>= 3.2'
+  spec.add_dependency 'rack'
   spec.add_dependency 'semantic_logger', '~> 4.4'
 end


### PR DESCRIPTION
### Issue # (if available)

The number of dependencies Rails gem is requiring is growing by at least 2 gems with every major release. Rails Semantic Logger doesn't need 14 dependencies to run.

### Description of changes

I replaced the `rails` gem with the `railties` which results in a lighter dependencies footprint, which means it installs faster and actually let's the end-user to decide if they want to bring Sprockets as a dependency.

I'm not sure if this is the right way to achieve what I want, please advise if changes are needed. Thanks a lot for all this amazing work!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
