### PR TITLE
Travis: Drop unused configuration sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,6 @@ jdk:
 
 bundler_args: --without development
 
-sudo: false
-
 # Gitter integration
 notifications:
   webhooks:


### PR DESCRIPTION
### Description of changes

This PR drops a now-unused configuration directive in the CI file. This simplifies the file.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
