### PR TITLE
Fix logging of SQL queries when query cache is in use

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -165,13 +165,13 @@ module RailsSemanticLogger
       if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR.zero? && Rails::VERSION::TINY <= 2 # 5.0.0 - 5.0.2
         alias bind_values bind_values_v5_0_0
         alias render_bind render_bind_v5_0_0
-      elsif Rails::VERSION::MAJOR >= 5 &&
+      elsif Rails::VERSION::MAJOR == 5 &&
             ((Rails::VERSION::MINOR.zero? && Rails::VERSION::TINY <= 6) ||
               (Rails::VERSION::MINOR == 1 && Rails::VERSION::TINY <= 4)) # 5.0.3 - 5.0.6 && 5.1.0 - 5.1.4
         alias bind_values bind_values_v5_0_3
         alias render_bind render_bind_v5_0_3
         alias type_casted_binds type_casted_binds_v5_0_3
-      elsif Rails::VERSION::MAJOR >= 5 # ~> 5.1.5 && ~> 5.0.7
+      elsif Rails::VERSION::MAJOR >= 5 # ~> 5.1.5 && ~> 5.0.7 && 6.x.x
         alias bind_values bind_values_v5_1_5
         alias render_bind render_bind_v5_0_3
         alias type_casted_binds type_casted_binds_v5_1_5

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -30,6 +30,22 @@ class ActiveRecordTest < Minitest::Test
         assert actual[:payload][:sql], actual[:payload]
       end
 
+      it 'sql with query cache' do
+        Sample.cache { 2.times { Sample.where(name: 'foo').first } }
+
+        SemanticLogger.flush
+        actual = @mock_logger.message
+
+        if Rails.version.to_f >= 5.1
+          assert actual[:message].include?('Sample'), actual[:message]
+        else
+          assert actual[:message].include?('CACHE'), actual[:message]
+        end
+
+        assert actual[:payload], actual
+        assert actual[:payload][:sql], actual[:payload]
+      end
+
       it 'single bind value' do
         Sample.where(name: 'Jack').first
 


### PR DESCRIPTION
### Issue # (if available)
The following error was happening when using semantic logging with sidekiq + activerecord on Rails 6

```
Could not log "sql.active_record" event. TypeError: wrong argument type Proc (must respond to :each) ["/Users/arnaud.lachaume/Sites/rails_semantic_logger/lib/rails_semantic_logger/active_record/log_subscriber.rb:102:in `zip'", "/Users/arnaud.lachaume/Sites/rails_semantic_logger/lib/rails_semantic_logger/active_record/log_subscriber.rb:102:in `bind_values_v5_0_3'", "/Users/arnaud.lachaume/Sites/rails_semantic_logger/lib/rails_semantic_logger/active_record/log_subscriber.rb:33:in `sql'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/subscriber.rb:96:in `finish'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/log_subscriber.rb:107:in `finish'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications/fanout.rb:121:in `finish'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications/fanout.rb:48:in `block in finish'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications/fanout.rb:48:in `each'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications/fanout.rb:48:in `finish'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications/instrumenter.rb:44:in `finish_with_state'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications/instrumenter.rb:29:in `instrument'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activesupport-6.0.0.beta1/lib/active_support/notifications.rb:171:in `instrument'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/connection_adapters/abstract/query_cache.rb:111:in `block in cache_sql'", "/Users/arnaud.lachaume/.rvm/rubies/ruby-2.5.5/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/connection_adapters/abstract/query_cache.rb:108:in `cache_sql'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/connection_adapters/abstract/query_cache.rb:99:in `select_all'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/querying.rb:41:in `find_by_sql'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation.rb:660:in `block in exec_queries'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation.rb:678:in `skip_query_cache_if_necessary'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation.rb:647:in `exec_queries'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation.rb:506:in `load'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation.rb:235:in `records'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation.rb:230:in `to_ary'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation/finder_methods.rb:519:in `find_nth_with_limit'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation/finder_methods.rb:504:in `find_nth'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/relation/finder_methods.rb:120:in `first'", "/Users/arnaud.lachaume/Sites/rails_semantic_logger/test/active_record_test.rb:34:in `block (5 levels) in <class:ActiveRecordTest>'", "/Users/arnaud.lachaume/Sites/rails_semantic_logger/test/active_record_test.rb:34:in `times'", "/Users/arnaud.lachaume/Sites/rails_semantic_logger/test/active_record_test.rb:34:in `block (4 levels) in <class:ActiveRecordTest>'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/connection_adapters/abstract/query_cache.rb:60:in `cache'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.0.beta1/lib/active_record/query_cache.rb:11:in `cache'", "/Users/arnaud.lachaume/Sites/rails_semantic_logger/test/active_record_test.rb:34:in `block (3 levels) in <class:ActiveRecordTest>'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest/test.rb:98:in `block (3 levels) in run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest/test.rb:195:in `capture_exceptions'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest/test.rb:95:in `block (2 levels) in run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:265:in `time_it'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest/test.rb:94:in `block in run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest/test.rb:211:in `with_info_handler'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest/test.rb:93:in `run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:960:in `run_one_method'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:334:in `run_one_method'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:321:in `block (2 levels) in run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:320:in `each'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:320:in `block in run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:347:in `with_info_handler'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:319:in `run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:159:in `block in __run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:159:in `map'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:159:in `__run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:136:in `run'", "/Users/arnaud.lachaume/.rvm/gems/ruby-2.5.5/gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'"]
```

### Description of changes
The change relaxes the Rails version used for type binding in the `ActiveRecord::LogSubscriber` class so as to allow Rails 6 to use the `5_1_5` version of the binding methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.