### PR TITLE
Check the specific method existance for Spring after_fork

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -189,7 +189,7 @@ module RailsSemanticLogger
       Resque.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Resque)
 
       # Re-open appenders after Spring has forked a process
-      Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring)
+      Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)
     end
   end
 end


### PR DESCRIPTION
### Description of changes

There are several gems that open `Spring` module to register a new command:
https://github.com/jonleighton/spring-commands-rspec/blob/master/lib/spring/commands/rspec.rb
https://github.com/pluff/spring-commands-crystalball/blob/master/lib/spring/commands/crystalball.rb

So when we run an application without spring and reach this line:
```
Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring)
```
`Spring` is defined and it tries to invoke after_fork which doesn't exist in those gems.
This PR fixes this problem for apps running without Spring. With Spring this method exists. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
