### PR TITLE
Use Sidekiq.logger when Sidekiq::Logging is unavailable

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -108,7 +108,13 @@ module RailsSemanticLogger
       Resque.logger           = SemanticLogger[Resque] if defined?(Resque) && Resque.respond_to?(:logger)
 
       # Replace the Sidekiq logger
-      Sidekiq::Logging.logger = SemanticLogger[Sidekiq] if defined?(Sidekiq)
+      if defined?(Sidekiq)
+        if defined?(Sidekiq::Logging)
+          Sidekiq::Logging.logger = SemanticLogger[Sidekiq]
+        else
+          Sidekiq.logger = SemanticLogger[Sidekiq]
+        end
+      end
 
       # Replace the Sidetiq logger
       Sidetiq.logger          = SemanticLogger[Sidetiq] if defined?(Sidetiq)

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -108,13 +108,7 @@ module RailsSemanticLogger
       Resque.logger           = SemanticLogger[Resque] if defined?(Resque) && Resque.respond_to?(:logger)
 
       # Replace the Sidekiq logger
-      if defined?(Sidekiq)
-        if defined?(Sidekiq::Logging)
-          Sidekiq::Logging.logger = SemanticLogger[Sidekiq]
-        else
-          Sidekiq.logger = SemanticLogger[Sidekiq]
-        end
-      end
+      Sidekiq.logger = SemanticLogger[Sidekiq] if defined?(Sidekiq)
 
       # Replace the Sidetiq logger
       Sidetiq.logger          = SemanticLogger[Sidetiq] if defined?(Sidetiq)


### PR DESCRIPTION
### Issue # (if available)

Resolves #94

Sidekiq 6.0 has deprecated usage of `Sidekiq::Logger`. `Sidekiq::Logger` is an internal module which applications should not be using. Instead applications should be using `Sidekiq.logger`, as is documented here: https://github.com/mperham/sidekiq/wiki/Logging#api-changes

### Description of changes

This PR attempts to stay backwards compatible by keeping the existing behaviour when `Sidekiq::Logging` still exists and use `Sidekiq.logger` when `Sidekiq::Logging` doesn't exist (which should be the case for Sidekiq 6.0+). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
