### PR TITLE
Fix unsubscribing notifications in rails v6

### DIFF
--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -30,8 +30,8 @@ module RailsSemanticLogger
   end
 
   def self.unattach(subscriber)
-    subscriber.patterns.each do |event|
-      ActiveSupport::Notifications.notifier.listeners_for(event).each do |sub|
+    subscriber_patterns(subscriber).each do |pattern|
+      ActiveSupport::Notifications.notifier.listeners_for(pattern).each do |sub|
         next unless sub.instance_variable_get(:@delegate) == subscriber
         ActiveSupport::Notifications.unsubscribe(sub)
       end
@@ -39,5 +39,12 @@ module RailsSemanticLogger
 
     ActiveSupport::LogSubscriber.subscribers.delete(subscriber)
   end
-  private_class_method :unattach
+
+  def self.subscriber_patterns(subscriber)
+    subscriber.patterns.respond_to?(:keys) ?
+      subscriber.patterns.keys :
+      subscriber.patterns
+  end
+
+  private_class_method :subscriber_patterns, :unattach
 end


### PR DESCRIPTION
Rails 6 store `AS::LogSubscriber#patterns` in a hash where key is
event pattern name rather than an array of event patterns names.

### Issue
Since Rails version 6, default Rails log subscribers aren't unsubscribed to be replaced by semantic logger so their messages keep showing in log output.

### Description of changes
Detect how subscribed events object is storing patterns and get their list accordingly.

The change in Rails subscriber can be viewed in here
https://github.com/rails/rails/commit/ca19b7f5d86aa590077766cbe8006f952b6d4296#diff-e96e89d85fdb9861738081367cc402e0R124


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
