### PR TITLE
Omit request and response from output

### DIFF
--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -38,8 +38,12 @@ module RailsSemanticLogger
           end
 
           payload[:status_message] = ::Rack::Utils::HTTP_STATUS_CODES[payload[:status]] if payload[:status].present?
+
           # Causes excessive log output with Rails 5 RC1
           payload.delete(:headers)
+          # Causes recursion in Rails 6.1.rc1
+          payload.delete(:request)
+          payload.delete(:response)
 
           params = payload[:params]
           if params


### PR DESCRIPTION
Follow on from https://github.com/rocketjob/rails_semantic_logger/pull/110

### Description of changes

This avoids infinite recursion while trying to serialise Request and Response objects.

I'm not 100% comfortable with this, but neither `ActionDispatch::Request` nor `ActionDispatch::Response` objects can be serialised with `to_json` under Rails 6.1.rc1.

This work-around is possibly a bit too much of a hammer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
