### PR TITLE
ensure log_to_stdout is patched for startup

### DIFF
--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -1,4 +1,5 @@
 require "semantic_logger"
+require "rails_semantic_logger/extensions/rails/server" if defined?(Rails::Server)
 require "rails_semantic_logger/engine"
 
 module RailsSemanticLogger

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -144,7 +144,6 @@ module RailsSemanticLogger
         end
         require("rails_semantic_logger/extensions/active_job/logging") if defined?(::ActiveJob)
         require("rails_semantic_logger/extensions/active_model_serializers/logging") if defined?(ActiveModelSerializers)
-        require("rails_semantic_logger/extensions/rails/server") if defined?(Rails::Server)
 
         if config.rails_semantic_logger.semantic
           # Active Job


### PR DESCRIPTION
### Issue # (if available)

#113

### Description of changes

In rocketjob/rails_semantic_logger#106 the order of requiring semantic logger extensions is changed as part of the change to add support of the "disabled" attribute. This appears to have the side-effect of not patching "log_to_stdout", in rails_semantic_logger/extensions/rails/server.rb, early enough to enable logging to STDOUT by default.

This commit reverts that one change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
