### PR TITLE
Adds allocations to the payload for controller, view, and sql logs

### DIFF
--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -37,6 +37,9 @@ module RailsSemanticLogger
             payload[key] = payload[key].to_f.round(2) if key.to_s =~ /(.*)_runtime/
           end
 
+          # Rails 6+ includes allocation count
+          payload[:allocations] = event.allocations if event.respond_to?(:allocations)
+
           payload[:status_message] = ::Rack::Utils::HTTP_STATUS_CODES[payload[:status]] if payload[:status].present?
 
           # Causes excessive log output with Rails 5 RC1

--- a/lib/rails_semantic_logger/action_view/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_view/log_subscriber.rb
@@ -23,6 +23,7 @@ module RailsSemanticLogger
           template: from_rails_root(event.payload[:identifier])
         }
         payload[:within] = from_rails_root(event.payload[:layout]) if event.payload[:layout]
+        payload[:allocations] = event.allocations if event.respond_to?(:allocations)
 
         logger.measure(
           self.class.rendered_log_level,
@@ -40,6 +41,7 @@ module RailsSemanticLogger
         }
         payload[:within] = from_rails_root(event.payload[:layout]) if event.payload[:layout]
         payload[:cache]  = payload[:cache_hit] unless event.payload[:cache_hit].nil?
+        payload[:allocations] = event.allocations if event.respond_to?(:allocations)
 
         logger.measure(
           self.class.rendered_log_level,
@@ -59,6 +61,7 @@ module RailsSemanticLogger
           count:    event.payload[:count]
         }
         payload[:cache_hits] = payload[:cache_hits] if payload[:cache_hits]
+        payload[:allocations] = event.allocations if event.respond_to?(:allocations)
 
         logger.measure(
           self.class.rendered_log_level,

--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -31,6 +31,7 @@ module RailsSemanticLogger
 
         log_payload         = {sql: payload[:sql]}
         log_payload[:binds] = bind_values(payload) unless (payload[:binds] || []).empty?
+        log_payload[:allocations] = event.allocations if event.respond_to?(:allocations)
 
         log = {
           message:  name,

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -28,6 +28,7 @@ class ActiveRecordTest < Minitest::Test
         assert actual[:message].include?("Sample"), actual[:message]
         assert actual[:payload], actual
         assert actual[:payload][:sql], actual[:payload]
+        assert_instance_of Integer, actual[:payload][:allocations] if Rails.version.to_i >= 6
       end
 
       it "sql with query cache" do

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -61,5 +61,6 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "OK", payload[:status_message], payload
     assert (payload[:view_runtime] >= 0.0), payload
     assert((payload[:db_runtime] >= 0.0), payload) unless defined?(JRuby)
+    assert_instance_of Integer, payload[:allocations] if Rails.version.to_i >= 6
   end
 end


### PR DESCRIPTION
### Description of changes

Since Rails 6, allocations have been logged during ActionController request logging, ActionView rendering, and ActiveRecord querying. This change adds those metrics to the payload (similar to `db_runtime` and `view_runtime`).

A concern: `allocations` is on `event` rather than `event.payload`, so this doesn't quite match up like `duration` does, so we would need to make changes to `SemanticLogger` to move `allocations` up to the log struct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
